### PR TITLE
Remove bracketlens from recommended extensions.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
     "recommendations": [
         "ms-python.python",
-        "wraith13.bracket-lens",
         "pustelto.bracketeer",
         "mikestead.dotenv",
         "janisdd.vscode-edit-csv",


### PR DESCRIPTION
It's not very useful for python.